### PR TITLE
changing how audio meter configured

### DIFF
--- a/Recorder/App.config
+++ b/Recorder/App.config
@@ -12,7 +12,7 @@
     <add key="OutputDirectoryName" value="c:\work\output" />
     <add key="WorkingDirectoryName" value="c:\work\temp" />
     <add key="FFMPEGArguments" value="-stats -f dshow -i video=&quot;Logitech QuickCam Pro 9000&quot;:audio=&quot;Microphone (Pro 9000)&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  />
-    <!-- <add key="FFMPEGArguments" value="-stats -f dshow -i video=&quot;Decklink Video Capture&quot;:audio=&quot;Decklink Audio Capture&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  /> -->
+    <!-- <add key="FFMPEGArguments" value="-rtbufsize 1500M -stats -f decklink -i &quot;DeckLink Studio 4K@1&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  /> -->
     <add key="BarcodeScannerIdentifiers" value="VID_040B&amp;PID_6543"/>
   </appSettings>
   <runtime>

--- a/Recorder/App.config
+++ b/Recorder/App.config
@@ -11,8 +11,8 @@
     <add key="PathToFFProbe" value="C:\Dependencies\ffmpeg\ffprobe.exe" />
     <add key="OutputDirectoryName" value="c:\work\output" />
     <add key="WorkingDirectoryName" value="c:\work\temp" />
-    <add key="AudioDeviceToMonitor" value="Microphone (Pro 9000a)" />
-    <add key="FFMPEGArguments" value="-stats -f dshow -i video=&quot;Logitech QuickCam Pro 9000&quot;:audio=&quot;Microphone (Pro 9000)&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  />
+    <add key="AudioDeviceToMonitor" value="Microphone (Pro 9000)" />
+    <add key="FFMPEGArguments" value="-rtbufsize 1500M -stats -f dshow -i video=&quot;Logitech QuickCam Pro 9000&quot;:audio=&quot;Microphone (Pro 9000)&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  />
     <!-- <add key="FFMPEGArguments" value="-rtbufsize 1500M -stats -f decklink -i &quot;DeckLink Studio 4K@1&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  /> -->
     <add key="BarcodeScannerIdentifiers" value="VID_040B&amp;PID_6543"/>
   </appSettings>

--- a/Recorder/App.config
+++ b/Recorder/App.config
@@ -11,6 +11,7 @@
     <add key="PathToFFProbe" value="C:\Dependencies\ffmpeg\ffprobe.exe" />
     <add key="OutputDirectoryName" value="c:\work\output" />
     <add key="WorkingDirectoryName" value="c:\work\temp" />
+    <add key="AudioDeviceToMonitor" value="Microphone (Pro 9000)" />
     <add key="FFMPEGArguments" value="-stats -f dshow -i video=&quot;Logitech QuickCam Pro 9000&quot;:audio=&quot;Microphone (Pro 9000)&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  />
     <!-- <add key="FFMPEGArguments" value="-rtbufsize 1500M -stats -f decklink -i &quot;DeckLink Studio 4K@1&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  /> -->
     <add key="BarcodeScannerIdentifiers" value="VID_040B&amp;PID_6543"/>

--- a/Recorder/App.config
+++ b/Recorder/App.config
@@ -11,7 +11,7 @@
     <add key="PathToFFProbe" value="C:\Dependencies\ffmpeg\ffprobe.exe" />
     <add key="OutputDirectoryName" value="c:\work\output" />
     <add key="WorkingDirectoryName" value="c:\work\temp" />
-    <add key="AudioDeviceToMonitor" value="Microphone (Pro 9000)" />
+    <add key="AudioDeviceToMonitor" value="Microphone (Pro 9000a)" />
     <add key="FFMPEGArguments" value="-stats -f dshow -i video=&quot;Logitech QuickCam Pro 9000&quot;:audio=&quot;Microphone (Pro 9000)&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  />
     <!-- <add key="FFMPEGArguments" value="-rtbufsize 1500M -stats -f decklink -i &quot;DeckLink Studio 4K@1&quot; -acodec pcm_s24le -strict -2 -ar 48000 -vcodec ffv1 -level 3 -threads 8 -coder 1 -context 1 -g 1 -slices 24 -slicecrc 1 -pix_fmt yuv422p10le"  /> -->
     <add key="BarcodeScannerIdentifiers" value="VID_040B&amp;PID_6543"/>

--- a/Recorder/Dialogs/OutputWindow.xaml
+++ b/Recorder/Dialogs/OutputWindow.xaml
@@ -20,6 +20,7 @@
             <controls:AudioMeter Grid.Row="0" Padding="8,16,8,8" DataContext="{Binding VolumeMeterViewModel}" Background="LightGray" Visibility="{Binding VolumeMeterVisibility}" />
             <controls:FrameStats Grid.Row="1" Padding="8,8,8,16" DataContext="{Binding FrameStatsViewModel}" Background="LightGray" />
             <TextBox Name="OutputText" Grid.Row="2" 
+                 FontFamily="Consolas" FontSize="10pt"
                  IsUndoEnabled="False" IsTabStop="False" IsReadOnly="True" IsReadOnlyCaretVisible="True" Text="{Binding Text, FallbackValue='testing'}" VerticalScrollBarVisibility="Visible" 
                  BorderThickness="0"
                  BorderBrush="LightGray"

--- a/Recorder/Models/ProgramSettings.cs
+++ b/Recorder/Models/ProgramSettings.cs
@@ -2,12 +2,13 @@
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
-using System.Security.RightsManagement;
 using Recorder.Exceptions;
+using Recorder.Utilities;
+using Recorder.ViewModels;
 
 namespace Recorder.Models
 {
-    public interface IProgramSettings
+    public interface IProgramSettings : ICanLogConfiguration
     {
         string ProjectCode { get; }
         string PathToFFMPEG { get; }
@@ -17,7 +18,7 @@ namespace Recorder.Models
         string FFMPEGArguments { get; }
 
         string WorkingFolder { get; }
-        
+
         string[] BarcodeScannerIdentifiers { get; }
 
         string AudioDeviceToMonitor { get; }
@@ -35,24 +36,10 @@ namespace Recorder.Models
             FFMPEGArguments = settings["FFMPEGArguments"];
             WorkingFolder = settings["WorkingDirectoryName"];
             PathToFFProbe = settings["PathToFFProbe"];
-            BarcodeScannerIdentifiers =ToArray(settings["BarcodeScannerIdentifiers"]);
+            BarcodeScannerIdentifiers = ToArray(settings["BarcodeScannerIdentifiers"]);
             AudioDeviceToMonitor = settings["AudioDeviceToMonitor"];
         }
 
-
-
-
-        private static string[] ToArray(string value)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return new string[0];
-            }
-
-            return value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(s => s.Trim()).ToArray();
-        }
-        
 
         public string ProjectCode { get; }
         public string PathToFFMPEG { get; }
@@ -94,6 +81,30 @@ namespace Recorder.Models
             {
                 throw new ConfigurationException("OutputFolder in app.config is not set or invalid");
             }
+        }
+
+        public void LogConfiguration(OutputWindowViewModel outputModel)
+        {
+            outputModel.WriteLine($"Project code: {ProjectCode}");
+            outputModel.WriteLine($"FFMPEG Path: {PathToFFMPEG}");
+            outputModel.WriteLine($"FFProbe Path: {PathToFFProbe}");
+            outputModel.WriteLine($"FFMPEG Arguments: {FFMPEGArguments}");
+            outputModel.WriteLine($"Working folder: {WorkingFolder}");
+            outputModel.WriteLine($"Output folder: {OutputFolder}");
+            outputModel.WriteLine($"Barcode scanner identifiers: {string.Join(", ", BarcodeScannerIdentifiers)}");
+            outputModel.WriteLine($"Audio device to monitor: {AudioDeviceToMonitor}");
+        }
+
+
+        private static string[] ToArray(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return new string[0];
+            }
+
+            return value.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => s.Trim()).ToArray();
         }
     }
 }

--- a/Recorder/Models/ProgramSettings.cs
+++ b/Recorder/Models/ProgramSettings.cs
@@ -20,6 +20,8 @@ namespace Recorder.Models
         
         string[] BarcodeScannerIdentifiers { get; }
 
+        string AudioDeviceToMonitor { get; }
+
         void Verify();
     }
 
@@ -34,6 +36,7 @@ namespace Recorder.Models
             WorkingFolder = settings["WorkingDirectoryName"];
             PathToFFProbe = settings["PathToFFProbe"];
             BarcodeScannerIdentifiers =ToArray(settings["BarcodeScannerIdentifiers"]);
+            AudioDeviceToMonitor = settings["AudioDeviceToMonitor"];
         }
 
 
@@ -58,6 +61,8 @@ namespace Recorder.Models
         public string FFMPEGArguments { get; }
         public string WorkingFolder { get; }
         public string[] BarcodeScannerIdentifiers { get; }
+        public string AudioDeviceToMonitor { get; }
+
         public void Verify()
         {
             if (string.IsNullOrWhiteSpace(ProjectCode))

--- a/Recorder/Properties/AssemblyInfo.cs
+++ b/Recorder/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/Recorder/Recorder.csproj
+++ b/Recorder/Recorder.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Dialogs\OutputWindow.xaml.cs">
       <DependentUpon>OutputWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utilities\ICanLogConfiguration.cs" />
     <Compile Include="Utilities\VolumeMeter.cs" />
     <Compile Include="ViewModels\AbstractNotifyModel.cs" />
     <Compile Include="ViewModels\AskExitViewModel.cs" />

--- a/Recorder/ReleaseNotes.txt
+++ b/Recorder/ReleaseNotes.txt
@@ -3,3 +3,5 @@
 1.2.0.0	10/22/2015	combiner should now write logs
 1.3.0.0	11/03/2015	added audio meter
 					added dropped, duplicate frames display
+1.4.0.0	11/10/2015	changing how audio meter is configured
+					adding configuration logging at startup

--- a/Recorder/Utilities/BarcodeHandler.cs
+++ b/Recorder/Utilities/BarcodeHandler.cs
@@ -9,7 +9,7 @@ using Recorder.ViewModels;
 
 namespace Recorder.Utilities
 {
-    public class BarcodeHandler : IDisposable
+    public class BarcodeHandler : IDisposable, ICanLogConfiguration
     {
         private readonly string[] _barcodeScannerIdentifiers;
         private readonly List<char> _buffer = new List<char>();
@@ -79,6 +79,11 @@ namespace Recorder.Utilities
 
             _viewModel.BarcodePanelViewModel.Barcode = value;
             await _viewModel.ShowPanel<BarcodePanelViewModel>();
+        }
+
+        public void LogConfiguration(OutputWindowViewModel outputModel)
+        {
+            outputModel.WriteLine("Barcode scanner: initialized");
         }
     }
 }

--- a/Recorder/Utilities/CombiningEngine.cs
+++ b/Recorder/Utilities/CombiningEngine.cs
@@ -36,7 +36,7 @@ namespace Recorder.Utilities
 
         public void Combine()
         {
-            if (OkToCombine().IsValid == false)
+            if (OkToProcess().IsValid == false)
             {
                 return;
             }
@@ -90,25 +90,6 @@ namespace Recorder.Utilities
             }
         }
 
-        public ValidationResult OkToCombine()
-        {
-            if (!File.Exists(Settings.PathToFFMPEG))
-            {
-                return new ValidationResult(false, "invalid FFMPEG path");
-            }
-
-            if (!Directory.Exists(Settings.WorkingFolder))
-            {
-                return new ValidationResult(false, "working folder does not exist");
-            }
-
-            if (!Directory.Exists(Settings.OutputFolder))
-            {
-                return new ValidationResult(false, "output folder does not exist");
-            }
-
-            return ObjectModel.FilePartsValid();
-        }
 
         private void GenerateCombineList()
         {
@@ -130,6 +111,42 @@ namespace Recorder.Utilities
             }
 
             IssueNotifyModel.Notify(GetErrorMessageFromOutput("Something went wrong while combining parts: {0}"));
+        }
+
+        protected override ValidationResult IsGlobalConfigurationOk()
+        {
+            var baseResult = base.IsGlobalConfigurationOk();
+            if (!baseResult.IsValid)
+            {
+                return baseResult;
+            }
+
+            if (!File.Exists(Settings.PathToFFMPEG))
+            {
+                return new ValidationResult(false, "invalid FFMPEG path");
+            }
+
+            if (!File.Exists(Settings.PathToFFProbe))
+            {
+                return new ValidationResult(false, "invalid FFProbe path");
+            }
+
+            return ValidationResult.ValidResult;
+        }
+
+        public override void LogConfiguration(OutputWindowViewModel outputModel)
+        {
+            var globalConfigOk = IsGlobalConfigurationOk();
+            if (globalConfigOk.IsValid)
+            {
+                outputModel.WriteLine("Combiner: initialized");
+            }
+            else
+            {
+                outputModel.WriteLine("Combiner: not initialized");
+                outputModel.WriteLine($"Combiner: {globalConfigOk.ErrorContent}");
+                outputModel.WriteLine("");
+            }
         }
     }
 }

--- a/Recorder/Utilities/ICanLogConfiguration.cs
+++ b/Recorder/Utilities/ICanLogConfiguration.cs
@@ -1,0 +1,9 @@
+﻿using Recorder.ViewModels;
+
+namespace Recorder.Utilities
+{
+    public interface ICanLogConfiguration
+    {
+        void LogConfiguration(OutputWindowViewModel outputModel);
+    }
+}

--- a/Recorder/ViewModels/FinishPanelViewModel.cs
+++ b/Recorder/ViewModels/FinishPanelViewModel.cs
@@ -69,7 +69,7 @@ namespace Recorder.ViewModels
             get
             {
                 return _combineCommand
-                       ?? (_combineCommand = new RelayCommand(param => DoCombine(), param => Combiner.OkToCombine().IsValid));
+                       ?? (_combineCommand = new RelayCommand(param => DoCombine(), param => Combiner.OkToProcess().IsValid));
             }
         }
 

--- a/Recorder/ViewModels/OutputWindowViewModel.cs
+++ b/Recorder/ViewModels/OutputWindowViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Windows;
 using JetBrains.Annotations;
 
@@ -76,11 +77,17 @@ namespace Recorder.ViewModels
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-
         public void StartOutput(string header)
         {
             Visibility = Visibility.Visible;
             Text += $"{header}\n\n";
+        }
+
+        public void WriteLine(string text)
+        {
+            var builder = new StringBuilder(Text);
+            builder.AppendLine(text);
+            Text = builder.ToString();
         }
     }
 }

--- a/Recorder/ViewModels/RecordPanelViewModel.cs
+++ b/Recorder/ViewModels/RecordPanelViewModel.cs
@@ -105,7 +105,7 @@ namespace Recorder.ViewModels
             get
             {
                 return _recordCommand ?? (_recordCommand =
-                    new RelayCommand(async param => await DoRecordAction(), param => Recorder.OkToRecord().IsValid));
+                    new RelayCommand(async param => await DoRecordAction(), param => Recorder.OkToProcess().IsValid));
             }
         }
 

--- a/Recorder/ViewModels/UserControlsViewModel.cs
+++ b/Recorder/ViewModels/UserControlsViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows;
@@ -39,6 +40,7 @@ namespace Recorder.ViewModels
 
             ConfigurePanels(objectModel);
 
+            LogConfiguration();
          
         }
 
@@ -53,9 +55,7 @@ namespace Recorder.ViewModels
 
             RegisterChildViewModels();
         }
-
         
-
         private void RegisterChildViewModels()
         {
             foreach (var child in Panels.Select(p => p as INotifyPropertyChanged).Where(p => p != null))
@@ -130,8 +130,6 @@ namespace Recorder.ViewModels
                     param =>EnableShowOutputCommand()));
             }
         }
-
-
         
         private bool EnableShowOutputCommand()
         {
@@ -163,6 +161,19 @@ namespace Recorder.ViewModels
             Recorder?.Dispose();
             Combiner?.Dispose();
             BarcodeHandler?.Dispose();
+        }
+
+        private void LogConfiguration()
+        {
+            OutputWindowViewModel.WriteLine($"{Title} ({Assembly.GetExecutingAssembly().GetName().Version})");
+            OutputWindowViewModel.WriteLine("");
+            ProgramSettings.LogConfiguration(OutputWindowViewModel);
+            OutputWindowViewModel.WriteLine("");
+            BarcodeHandler.LogConfiguration(OutputWindowViewModel);
+            Combiner.LogConfiguration(OutputWindowViewModel);
+            Recorder.LogConfiguration(OutputWindowViewModel);
+           
+            
         }
     }
 }


### PR DESCRIPTION
Audio meter is now no longer automatically configured -- the audio source to monitor needs to be configured in the .config file.

If this value is missing or invalid, the recorder will log possible correct values in the output window.
