### PR TITLE
fix startup flickering issue

### DIFF
--- a/Packager/Properties/AssemblyInfo.cs
+++ b/Packager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.0.0")]
-[assembly: AssemblyFileVersion("3.1.0.0")]
+[assembly: AssemblyVersion("3.2.0.0")]
+[assembly: AssemblyFileVersion("3.2.0.0")]

--- a/Packager/ReleaseNotes.txt
+++ b/Packager/ReleaseNotes.txt
@@ -62,5 +62,7 @@
 							 0 = success (or nothing to do)
 							-1 = issue occurred while processing one or more objects
 							-2 = engine issue occurred
+3.2.0.0		8/1/2016	fixing issue that was causing a series of flickering  windows to be shown 
+						at startup.
 
 					

--- a/Packager/Utilities/Configuration/ConfigurationLogger.cs
+++ b/Packager/Utilities/Configuration/ConfigurationLogger.cs
@@ -50,8 +50,7 @@ namespace Packager.Utilities.Configuration
             Observers.Log("Unit prefix: {0}", ProgramSettings.UnitPrefix.ToDefaultIfEmpty("[not set]"));
             Observers.Log("");
             Observers.Log("FFMPEG path: {0}",ProgramSettings.FFMPEGPath.ToDefaultIfEmpty("[not set]"));
-            Observers.Log("FFMPEG version: {0}",
-                (await FFMPEGRunner.GetFFMPEGVersion()).ToDefaultIfEmpty("[not available]"));
+            Observers.Log("FFMPEG version: {0}", (await FFMPEGRunner.GetFFMPEGVersion()).ToDefaultIfEmpty("[not available]"));
             Observers.Log("FFMPeg audio production args: {0}",
                 ProgramSettings.FFMPEGAudioProductionArguments.ToDefaultIfEmpty("[not set]"));
             Observers.Log("FFMPeg audio access args: {0}",
@@ -63,8 +62,7 @@ namespace Packager.Utilities.Configuration
             Observers.Log("");
             Observers.Log("FFProbe path: {0}",
                 ProgramSettings.FFProbePath.ToDefaultIfEmpty("[not set]"));
-            Observers.Log("FFProbe version: {0}",
-                (await FFProbeRunner.GetVersion()).ToDefaultIfEmpty("[not available]"));
+            Observers.Log("FFProbe version: {0}", (await FFProbeRunner.GetVersion()).ToDefaultIfEmpty("[not available]"));
             Observers.Log("FFProbe video QC args: {0}",
                 FFProbeRunner.VideoQualityControlArguments.ToDefaultIfEmpty("[not set]"));
             Observers.Log("");

--- a/Packager/Utilities/ProcessRunners/AbstractFFMPEGRunner.cs
+++ b/Packager/Utilities/ProcessRunners/AbstractFFMPEGRunner.cs
@@ -50,8 +50,11 @@ namespace Packager.Utilities.ProcessRunners
                     Arguments = "-version",
                     RedirectStandardError = true,
                     RedirectStandardOutput = true,
-                    RedirectStandardInput = true
+                    RedirectStandardInput = true,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden
                 };
+
                 var result = await ProcessRunner.Run(info, CancellationToken.None);
 
                 var parts = result.StandardOutput.GetContent().Split(' ');
@@ -138,7 +141,8 @@ namespace Packager.Utilities.ProcessRunners
                 RedirectStandardOutput = true,
                 RedirectStandardInput = true,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden
             };
 
             var result = await ProcessRunner.Run(startInfo, cancellationToken);

--- a/Packager/Utilities/ProcessRunners/BwfMetaEditRunner.cs
+++ b/Packager/Utilities/ProcessRunners/BwfMetaEditRunner.cs
@@ -26,14 +26,7 @@ namespace Packager.Utilities.ProcessRunners
             BwfMetaEditPath = programSettings.BwfMetaEditPath;
             BaseProcessingDirectory = programSettings.ProcessingDirectory;
         }
-
-      /*  public BwfMetaEditRunner(IProcessRunner processRunner, string bwfMetaEditPath, string baseProcessingDirectory)
-        {
-            ProcessRunner = processRunner;
-            BwfMetaEditPath = bwfMetaEditPath;
-            BaseProcessingDirectory = baseProcessingDirectory;
-        }*/
-
+        
         private IProcessRunner ProcessRunner { get; }
         private string BaseProcessingDirectory { get; }
      
@@ -77,6 +70,7 @@ namespace Packager.Utilities.ProcessRunners
                 RedirectStandardOutput = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden
             };
 
             return await ProcessRunner.Run(startInfo, cancellationToken);

--- a/Packager/Utilities/ProcessRunners/FFProbeRunner.cs
+++ b/Packager/Utilities/ProcessRunners/FFProbeRunner.cs
@@ -97,7 +97,9 @@ namespace Packager.Utilities.ProcessRunners
                     Arguments = "-version",
                     RedirectStandardError = true,
                     RedirectStandardOutput = true,
-                    RedirectStandardInput = true
+                    RedirectStandardInput = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true
                 };
                 var result = await ProcessRunner.Run(info, CancellationToken.None);
 
@@ -153,6 +155,7 @@ namespace Packager.Utilities.ProcessRunners
                 RedirectStandardInput = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
                 WorkingDirectory = workingFolder
             };
 


### PR DESCRIPTION
Quick fix to remove flickering windows when application started. This was caused by the various version checks for ffmpeg, etc. I forgot to tell those processes not to show their windows.
