### PR TITLE
Use manifest file when importing label images

### DIFF
--- a/Packager.Test/Processors/AudioProcessorTests.cs
+++ b/Packager.Test/Processors/AudioProcessorTests.cs
@@ -386,7 +386,7 @@ namespace Packager.Test.Processors
                 [Test]
                 public void ItShouldCallExportToFileCorrectly()
                 {
-                    XmlExporter.Received().ExportToFile(Arg.Is<IU>(iu => iu.Carrier.Equals(AudioCarrier)),
+                    XmlExporter.Received().ExportToFile(Arg.Is<ExportableManifest>(iu => iu.Carrier.Equals(AudioCarrier)),
                         Path.Combine(ExpectedProcessingDirectory, XmlManifestFileName));
                 }
 

--- a/Packager.Test/Processors/VideoProcessorTests.cs
+++ b/Packager.Test/Processors/VideoProcessorTests.cs
@@ -389,7 +389,7 @@ namespace Packager.Test.Processors
                 [Test]
                 public void ItShouldCallExportToFileCorrectly()
                 {
-                    XmlExporter.Received().ExportToFile(Arg.Is<IU>(iu => iu.Carrier.Equals(VideoCarrier)),
+                    XmlExporter.Received().ExportToFile(Arg.Is<ExportableManifest>(iu => iu.Carrier.Equals(VideoCarrier)),
                         Path.Combine(ExpectedProcessingDirectory, XmlManifestFileName));
                 }
 

--- a/Packager.Test/Utilities/ImageImporterTests.cs
+++ b/Packager.Test/Utilities/ImageImporterTests.cs
@@ -10,6 +10,7 @@ using Packager.Models.SettingsModels;
 using Packager.Providers;
 using Packager.Utilities.Hashing;
 using Packager.Utilities.Images;
+using Packager.Utilities.Xml;
 
 namespace Packager.Test.Utilities
 {
@@ -26,6 +27,7 @@ namespace Packager.Test.Utilities
         private IDirectoryProvider DirectoryProvider { get; set; }
         private IHasher Hasher { get; set; }
         private ILabelImageImporter ImageImporter { get; set; }
+        private IXmlExporter XmlExporter { get; set; }
 
         private List<string> SourceFiles { get; set; }
         private static string ValidFilename1 => $"{ProjectCode}_{Barcode}_01_label.tif";
@@ -53,7 +55,9 @@ namespace Packager.Test.Utilities
             Hasher.Hash(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(args => $"{Path.GetFileName(args.Arg<string>())} hash");
 
-            ImageImporter = new LabelImageImporter(Settings, FileProvider, DirectoryProvider, Hasher);
+            XmlExporter = Substitute.For<IXmlExporter>();
+
+            ImageImporter = new LabelImageImporter(Settings, FileProvider, DirectoryProvider, Hasher, XmlExporter);
         }
 
         private string GetSourcePath(string filename)

--- a/Packager/Models/OutputModels/Carrier/RecordCarrier.cs
+++ b/Packager/Models/OutputModels/Carrier/RecordCarrier.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Packager.Models.OutputModels.Carrier
+{
+    [Serializable]
+    public class RecordCarrier:AudioCarrier
+    {
+    }
+}

--- a/Packager/Models/OutputModels/ExportableManifest.cs
+++ b/Packager/Models/OutputModels/ExportableManifest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Xml.Serialization;
+using Packager.Models.OutputModels.Carrier;
+
+namespace Packager.Models.OutputModels
+{
+    [Serializable]
+    [XmlRoot(ElementName = "IU")]
+    public class ExportableManifest
+    {
+        public AbstractCarrierData Carrier { get; set; }
+    }
+}

--- a/Packager/Models/OutputModels/IU.cs
+++ b/Packager/Models/OutputModels/IU.cs
@@ -5,10 +5,17 @@ using Packager.Models.OutputModels.Carrier;
 namespace Packager.Models.OutputModels
 {
     [Serializable]
+    [XmlRoot(ElementName = "IU")]
     public class IU
     {
         public AbstractCarrierData Carrier { get; set; }
     }
 
+    [Serializable]
+    [XmlRoot(ElementName = "IU")]
+    public class IU<T> where T: AbstractCarrierData
+    {
+        public T Carrier { get; set; }
+    }
     
 }

--- a/Packager/Models/OutputModels/ImportableManifest.cs
+++ b/Packager/Models/OutputModels/ImportableManifest.cs
@@ -6,14 +6,7 @@ namespace Packager.Models.OutputModels
 {
     [Serializable]
     [XmlRoot(ElementName = "IU")]
-    public class IU
-    {
-        public AbstractCarrierData Carrier { get; set; }
-    }
-
-    [Serializable]
-    [XmlRoot(ElementName = "IU")]
-    public class IU<T> where T: AbstractCarrierData
+    public class ImportableManifest<T> where T: AbstractCarrierData
     {
         public T Carrier { get; set; }
     }

--- a/Packager/Packager.csproj
+++ b/Packager/Packager.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Models\FileModels\XmlFile.cs" />
     <Compile Include="Models\OutputModels\Carrier\AudioCarrier.cs" />
     <Compile Include="Models\OutputModels\Carrier\RecordCarrier.cs" />
+    <Compile Include="Models\OutputModels\ExportableManifest.cs" />
     <Compile Include="Models\OutputModels\Ingest\AudioIngest.cs" />
     <Compile Include="Models\OutputModels\Carrier\VideoCarrier.cs" />
     <Compile Include="Models\OutputModels\Ingest\VideoIngest.cs" />
@@ -202,7 +203,7 @@
     <Compile Include="Models\EmailMessageModels\EngineIssueMessage.cs" />
     <Compile Include="Models\SettingsModels\IProgramSettings.cs" />
     <Compile Include="Models\OutputModels\BakingData.cs" />
-    <Compile Include="Models\OutputModels\IU.cs" />
+    <Compile Include="Models\OutputModels\ImportableManifest.cs" />
     <Compile Include="Models\OutputModels\ConfigurationData.cs" />
     <Compile Include="Models\OutputModels\CleaningData.cs" />
     <Compile Include="Models\OutputModels\File.cs" />

--- a/Packager/Packager.csproj
+++ b/Packager/Packager.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Models\FileModels\VideoPreservationIntermediateFile.cs" />
     <Compile Include="Models\FileModels\XmlFile.cs" />
     <Compile Include="Models\OutputModels\Carrier\AudioCarrier.cs" />
+    <Compile Include="Models\OutputModels\Carrier\RecordCarrier.cs" />
     <Compile Include="Models\OutputModels\Ingest\AudioIngest.cs" />
     <Compile Include="Models\OutputModels\Carrier\VideoCarrier.cs" />
     <Compile Include="Models\OutputModels\Ingest\VideoIngest.cs" />

--- a/Packager/Processors/AbstractProcessor.cs
+++ b/Packager/Processors/AbstractProcessor.cs
@@ -238,7 +238,7 @@ namespace Packager.Processors
             {
                 await AssignChecksumValues(filesToProcess, cancellationToken);
 
-                var wrapper = new IU {Carrier = CarrierDataFactory.Generate(metadata, ProgramSettings.DigitizingEntity, filesToProcess)};
+                var wrapper = new ExportableManifest {Carrier = CarrierDataFactory.Generate(metadata, ProgramSettings.DigitizingEntity, filesToProcess)};
                 XmlExporter.ExportToFile(wrapper, Path.Combine(ProcessingDirectory, result.Filename));
 
                 result.Checksum = await Hasher.Hash(result, cancellationToken);

--- a/Packager/Properties/AssemblyInfo.cs
+++ b/Packager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.4.0.0")]
-[assembly: AssemblyFileVersion("3.4.0.0")]
+[assembly: AssemblyVersion("3.5.0.0")]
+[assembly: AssemblyFileVersion("3.5.0.0")]

--- a/Packager/ReleaseNotes.txt
+++ b/Packager/ReleaseNotes.txt
@@ -66,4 +66,5 @@
 						at startup.
 3.3.0.0		2/13/2017	Packager will import label images
 3.4.0.0		2/13/2017	Fix issue finding image folders
+3.5.0.0		2/20/2017	Use manifest files when importing label images
 					

--- a/Packager/Utilities/Images/LabelImageImporter.cs
+++ b/Packager/Utilities/Images/LabelImageImporter.cs
@@ -61,7 +61,7 @@ namespace Packager.Utilities.Images
                 throw new FileNotFoundException("expected manifest file to be present", manifestPath);
             }
 
-            var manifest = XmlExporter.ImportFromFile<IU<RecordCarrier>>(manifestPath);
+            var manifest = XmlExporter.ImportFromFile<ImportableManifest<RecordCarrier>>(manifestPath);
             var fileEntries = manifest.Carrier.Parts.Sides.SelectMany(s => s.Files);
             // get .tiff file models
             var imageFiles = fileEntries

--- a/Packager/Utilities/Images/LabelImageImporter.cs
+++ b/Packager/Utilities/Images/LabelImageImporter.cs
@@ -4,11 +4,16 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Packager.Extensions;
 using Packager.Factories;
 using Packager.Models.FileModels;
+using Packager.Models.OutputModels;
+using Packager.Models.OutputModels.Carrier;
 using Packager.Models.SettingsModels;
 using Packager.Providers;
 using Packager.Utilities.Hashing;
+using Packager.Utilities.Xml;
+using File = Packager.Models.OutputModels.File;
 
 namespace Packager.Utilities.Images
 {
@@ -17,11 +22,13 @@ namespace Packager.Utilities.Images
         private IFileProvider FileProvider { get; }
         private IDirectoryProvider DirectoryProvider { get; }
         private IHasher Hasher { get; }
+        private IXmlExporter XmlExporter { get; }
+
         private string ImageDirectory { get; }
         private string ProjectCode { get; }
         private string BaseProcessingFolder { get; }
        
-        public LabelImageImporter(IProgramSettings settings, IFileProvider fileProvider, IDirectoryProvider directoryProvider, IHasher hasher)
+        public LabelImageImporter(IProgramSettings settings, IFileProvider fileProvider, IDirectoryProvider directoryProvider, IHasher hasher, IXmlExporter xmlExporter)
         {
             ProjectCode = settings.ProjectCode;
             ImageDirectory = settings.ImageDirectory;
@@ -30,6 +37,7 @@ namespace Packager.Utilities.Images
             FileProvider = fileProvider;
             DirectoryProvider = directoryProvider;
             Hasher = hasher;
+            XmlExporter = xmlExporter;
         }
 
         public async Task<List<AbstractFile>> ImportMediaImages(string barcode, CancellationToken cancellationToken)
@@ -46,31 +54,48 @@ namespace Packager.Utilities.Images
                 return new List<AbstractFile>();
             }
 
+            var manifestPath = Path.Combine(sourceFolder, $"{ProjectCode}_{barcode}.xml");
+            // import the manifest
+            if (FileProvider.FileDoesNotExist(manifestPath))
+            {
+                throw new FileNotFoundException("expected manifest file to be present", manifestPath);
+            }
+
+            var manifest = XmlExporter.ImportFromFile<IU<RecordCarrier>>(manifestPath);
+            var fileEntries = manifest.Carrier.Parts.Sides.SelectMany(s => s.Files);
             // get .tiff file models
-            var imageFiles = DirectoryProvider.EnumerateFiles(sourceFolder)
-                    .Select(FileModelFactory.GetModel)
-                    .Where(f => f is TiffImageFile)
-                    .Where(f=>f.IsValid())
-                    .ToList();
+            var imageFiles = fileEntries
+                .Select(entry => CreateFileAndAssignHash(entry, sourceFolder))
+                .Where(f => f is TiffImageFile)
+                .Where(f=>f.IsValid())
+                .ToList();
             
             // copy files to processing folder
             foreach (var file in imageFiles)
             {
                 var sourcePath = Path.Combine(sourceFolder, file.Filename);
                 var destPath = Path.Combine(BaseProcessingFolder, file.GetFolderName(), file.Filename);
-
-                var originalHash = await Hasher.Hash(sourcePath, cancellationToken);
+                
                 await FileProvider.CopyFileAsync(sourcePath, destPath, cancellationToken);
-                var destHash = await Hasher.Hash(destPath, cancellationToken);
+                var destChecksum = await Hasher.Hash(destPath, cancellationToken);
 
-                if (originalHash != destHash)
+                if (string.Equals(file.Checksum, destChecksum, StringComparison.InvariantCultureIgnoreCase)==false)
                 {
-                    throw new Exception($"copy hash ({destHash}) is not equal to original hash ({originalHash}).");
+                    throw new Exception($"copy hash ({destChecksum.ToUpperInvariant()}) is not equal to original hash ({file.Checksum.ToUpperInvariant()}).");
                 }
 
             }
 
             return imageFiles;
+        }
+
+        private static AbstractFile CreateFileAndAssignHash(File entry, string sourceFolder)
+        {
+            var result = FileModelFactory.GetModel(Path.Combine(sourceFolder, entry.FileName));
+            
+            result.Checksum = entry.Checksum.ToDefaultIfEmpty();
+            return result;
+
         }
     }
 }

--- a/Packager/Utilities/Images/LabelImageImporter.cs
+++ b/Packager/Utilities/Images/LabelImageImporter.cs
@@ -42,9 +42,11 @@ namespace Packager.Utilities.Images
 
         public async Task<List<AbstractFile>> ImportMediaImages(string barcode, CancellationToken cancellationToken)
         {
-            // 1 find images
-            // 2 copy images to processing directory
-            // return list of models
+            // 1 find image manifest file
+            // 2 use manifest to identify images
+            // 3 copy images to processing directory
+            // 4 verify hashes
+            // 5 return list of models
 
             // does folder exist?
             var sourceFolder = Path.Combine(ImageDirectory, $"{barcode}");
@@ -54,39 +56,49 @@ namespace Packager.Utilities.Images
                 return new List<AbstractFile>();
             }
 
+            // if so, verify that manifest exists
             var manifestPath = Path.Combine(sourceFolder, $"{ProjectCode}_{barcode}.xml");
-            // import the manifest
             if (FileProvider.FileDoesNotExist(manifestPath))
             {
-                throw new FileNotFoundException("expected manifest file to be present", manifestPath);
+                throw new FileNotFoundException("Label image manifest file not present", manifestPath);
             }
 
+            var destFolder = Path.Combine(BaseProcessingFolder, $"{ProjectCode}_{barcode}");
+            if (DirectoryProvider.DirectoryExists(destFolder) == false)
+            {
+                throw new DirectoryNotFoundException($"Invalid processing folder: {destFolder}");
+            }
+
+            // import the manifest
             var manifest = XmlExporter.ImportFromFile<ImportableManifest<RecordCarrier>>(manifestPath);
             var fileEntries = manifest.Carrier.Parts.Sides.SelectMany(s => s.Files);
             // get .tiff file models
-            var imageFiles = fileEntries
+            var labelFiles = fileEntries
                 .Select(entry => CreateFileAndAssignHash(entry, sourceFolder))
                 .Where(f => f is TiffImageFile)
                 .Where(f=>f.IsValid())
                 .ToList();
             
-            // copy files to processing folder
-            foreach (var file in imageFiles)
+            // copy files to processing folder and verify each file
+            foreach (var file in labelFiles)
             {
                 var sourcePath = Path.Combine(sourceFolder, file.Filename);
-                var destPath = Path.Combine(BaseProcessingFolder, file.GetFolderName(), file.Filename);
-                
+                var destPath = Path.Combine(destFolder, file.Filename);
+
                 await FileProvider.CopyFileAsync(sourcePath, destPath, cancellationToken);
-                var destChecksum = await Hasher.Hash(destPath, cancellationToken);
-
-                if (string.Equals(file.Checksum, destChecksum, StringComparison.InvariantCultureIgnoreCase)==false)
-                {
-                    throw new Exception($"copy hash ({destChecksum.ToUpperInvariant()}) is not equal to original hash ({file.Checksum.ToUpperInvariant()}).");
-                }
-
+                await VerifyFile(file, destPath, cancellationToken);
             }
 
-            return imageFiles;
+            return labelFiles;
+        }
+
+        private async Task VerifyFile(AbstractFile file, string destPath, CancellationToken cancellationToken)
+        {
+            var destChecksum = await Hasher.Hash(destPath, cancellationToken);
+            if (string.Equals(file.Checksum, destChecksum, StringComparison.InvariantCultureIgnoreCase) == false)
+            {
+                throw new Exception($"copy hash ({destChecksum.ToUpperInvariant()}) is not equal to original hash ({file.Checksum.ToUpperInvariant()}).");
+            }
         }
 
         private static AbstractFile CreateFileAndAssignHash(File entry, string sourceFolder)

--- a/Packager/Utilities/Xml/IXmlExporter.cs
+++ b/Packager/Utilities/Xml/IXmlExporter.cs
@@ -3,5 +3,6 @@
     public interface IXmlExporter
     {
         void ExportToFile(object o, string path);
+        T ImportFromFile<T>(string path) where T: class;
     }
 }

--- a/Packager/Utilities/Xml/XmlExporter.cs
+++ b/Packager/Utilities/Xml/XmlExporter.cs
@@ -22,5 +22,14 @@ namespace Packager.Utilities.Xml
                 xmlSerializer.Serialize(xmlWriter, o);
             }
         }
+
+        public T ImportFromFile<T>(string path) where T:class
+        {
+            var xmlSerializer = new XmlSerializer(typeof(T));
+            using (var stream = new FileStream(path, FileMode.Open))
+            {
+                return xmlSerializer.Deserialize(stream) as T;
+            }
+        }
     }
 }

--- a/Reporter/LineGenerators/OpenObjectLogFileLinkText.cs
+++ b/Reporter/LineGenerators/OpenObjectLogFileLinkText.cs
@@ -43,11 +43,7 @@ namespace Reporter.LineGenerators
         private void OpenLogFiles()
         {
             var editorPath = GetEditorPath();
-            if (!File.Exists(editorPath))
-            {
-                return;
-            }
-
+            
             if (!Directory.Exists(ReportFolder))
             {
                 return;
@@ -61,22 +57,29 @@ namespace Reporter.LineGenerators
 
         private static void OpenLogFile(string editorPath, string logPath)
         {
-            var startInfo = new ProcessStartInfo(editorPath)
+            try
             {
-                Arguments = logPath
-            };
+                var startInfo = new ProcessStartInfo(editorPath)
+                {
+                    Arguments = logPath
+                };
 
-            Process.Start(startInfo);
+                Process.Start(startInfo);
+            }
+            catch
+            {
+                // ignore
+            }
         }
 
-        private string GetEditorPath()
+        private static string GetEditorPath()
         {
-            var notepadPlusPlusPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Notepad++", "Notepad++.exe");
-            var notepadPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "Notepad.exe");
+            var notepadPlusPlusPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), 
+                "Notepad++", "Notepad++.exea");
 
             return File.Exists(notepadPlusPlusPath)
                 ? notepadPlusPlusPath
-                : notepadPath;
+                : "Notepad.exe";
         }
     }
 }


### PR DESCRIPTION
The packager should get its list of label images from the manifest file that accompanies the image. It should use the values in this file to verify each label image's checksum.