### PR TITLE
Fix issue if log path set incorrectly

### DIFF
--- a/Packager/Program.cs
+++ b/Packager/Program.cs
@@ -58,7 +58,8 @@ namespace Packager
             }
             catch (Exception e)
             {
-                // todo: log
+                var observers = container.GetInstance<IObserverCollection>();
+                observers?.LogEngineIssue(e);
             }
         }
 

--- a/Packager/Properties/AssemblyInfo.cs
+++ b/Packager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.1.0.0")]
+[assembly: AssemblyFileVersion("4.1.0.0")]

--- a/Packager/ReleaseNotes.txt
+++ b/Packager/ReleaseNotes.txt
@@ -75,4 +75,7 @@
 						Add specific coding-history generators for open-reel, 
 						cylinder, and lacquer disc formats
 						Use file_bext field from POD when embedding description fields
+4.1.0.0		5/18/2017	Fix issue that was causing packager to exit unexpectedly if
+						an invalid log path was specified.
+						Improve logging for unhandled exceptions
 					

--- a/Packager/UserInterface/OutputWindow.cs
+++ b/Packager/UserInterface/OutputWindow.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Windows;
 using Packager.Engine;
 using Packager.Models.SettingsModels;
+using Packager.Observers;
 
 namespace Packager.UserInterface
 {
@@ -14,8 +16,9 @@ namespace Packager.UserInterface
         private IProgramSettings ProgramSettings { get; }
         private IEngine Engine { get; }
         private CancellationTokenSource CancellationTokenSource { get; }
-    
-        public OutputWindow(IProgramSettings programSettings, IViewModel viewModel, IEngine engine, CancellationTokenSource cancellationTokenSource)
+        private IObserverCollection Observers { get; }
+
+        public OutputWindow(IProgramSettings programSettings, IViewModel viewModel, IEngine engine, IObserverCollection observers, CancellationTokenSource cancellationTokenSource)
         {
             InitializeComponent();
 
@@ -23,14 +26,23 @@ namespace Packager.UserInterface
             Engine = engine;
             CancellationTokenSource = cancellationTokenSource;
             ViewModel = viewModel;
-
             DataContext = viewModel;
+            Observers = observers;
         }
 
         private async void OnWindowLoaded(object sender, RoutedEventArgs e)
         {
-            ViewModel.Initialize(this, ProgramSettings.ProjectCode);
-            await Engine.Start(CancellationTokenSource.Token);
+            try
+            {
+                ViewModel.Initialize(this, ProgramSettings.ProjectCode);
+                await Engine.Start(CancellationTokenSource.Token);
+            }
+            catch (Exception exception)
+            {
+                Observers.LogEngineIssue(exception);
+            }
+            
+            
         }
     }
 }

--- a/Packager/UserInterface/OutputWindow.cs
+++ b/Packager/UserInterface/OutputWindow.cs
@@ -2,6 +2,8 @@
 using System.Threading;
 using System.Windows;
 using Packager.Engine;
+using Packager.Exceptions;
+using Packager.Models.ProgramArgumentsModels;
 using Packager.Models.SettingsModels;
 using Packager.Observers;
 
@@ -17,12 +19,14 @@ namespace Packager.UserInterface
         private IEngine Engine { get; }
         private CancellationTokenSource CancellationTokenSource { get; }
         private IObserverCollection Observers { get; }
+        private IProgramArguments ProgramArguments { get; }
 
-        public OutputWindow(IProgramSettings programSettings, IViewModel viewModel, IEngine engine, IObserverCollection observers, CancellationTokenSource cancellationTokenSource)
+        public OutputWindow(IProgramSettings programSettings, IViewModel viewModel, IEngine engine, IObserverCollection observers, IProgramArguments arguments, CancellationTokenSource cancellationTokenSource)
         {
             InitializeComponent();
 
             ProgramSettings = programSettings;
+            ProgramArguments = arguments;
             Engine = engine;
             CancellationTokenSource = cancellationTokenSource;
             ViewModel = viewModel;
@@ -40,6 +44,10 @@ namespace Packager.UserInterface
             catch (Exception exception)
             {
                 Observers.LogEngineIssue(exception);
+                if (ProgramArguments.Interactive == false)
+                {
+                    throw new LoggedException(exception);
+                }
             }
             
             


### PR DESCRIPTION
- Fix issue that was causing packager to exit unexpectedly if an invalid log path was specified.      - prove logging for unhandled exceptions