### PR TITLE
Support lp format

### DIFF
--- a/Packager/Program.cs
+++ b/Packager/Program.cs
@@ -147,6 +147,7 @@ namespace Packager
                 { MediaFormats.Cdr, new CdrCodingHistoryGenerator() },
                 { MediaFormats.LacquerDisc, new LacquerOrCylinderCodingHistoryGenerator()},
                 { MediaFormats.LacquerDiscIrene, new LacquerDiscIreneCodingHistoryGenerator()},
+                { MediaFormats.Lp, new StandardCodingHistoryGenerator() },
                 { MediaFormats.Cylinder, new LacquerOrCylinderCodingHistoryGenerator() },
                 { MediaFormats.AluminumDisc, new LacquerOrCylinderCodingHistoryGenerator()},
                 { MediaFormats.OtherAnalogSoundDisc, new LacquerOrCylinderCodingHistoryGenerator() },

--- a/Packager/Properties/AssemblyInfo.cs
+++ b/Packager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.17.0.0")]
-[assembly: AssemblyFileVersion("4.17.0.0")]
+[assembly: AssemblyVersion("4.18.0.0")]
+[assembly: AssemblyFileVersion("4.18.0.0")]

--- a/Packager/ReleaseNotes.txt
+++ b/Packager/ReleaseNotes.txt
@@ -99,4 +99,5 @@
 4.15.0.0   12/17/2019   Add 78 coding history generator
 4.16.0.0   08/07/2020   Configure packager to use TLS 1.2
 4.17.0.0   03/24/2021   Add support for Magnabelt format
+4.18.0.0   08/17/2023   Add support for Lp format
 					


### PR DESCRIPTION
This PR adds coding history support for the LP format. For now, we're using the standard coding history generator, which produces the following coding history block:

```
A=ANALOGUE,M=Stereo,T=Technics SP-15;SNIUMDS 01;33 rpm;Lp, 
A=PCM,F=96000,W=24,M=Stereo,T=Prism Dream ADA-8XR;SN00770;A/D, 
A=PCM,F=96000,W=24,M=Stereo,T=Lynx AES16;DIO
```
We still need to have Dan review these changes to ensure that everything looks correct, and will merge or fix issues once he's had a chance to review this.
